### PR TITLE
Generate GraphQL types for empty proto messages

### DIFF
--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -111,10 +111,6 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	var packages []*spec.Package
 
 	for _, m := range g.messages {
-		// skip empty field message, otherwise graphql-go raise error
-		if len(m.Fields()) == 0 {
-			continue
-		}
 		if m.IsDepended(spec.DependTypeMessage, file.Package()) {
 			switch {
 			case file.Package() == m.Package():

--- a/protoc-gen-graphql/template.go
+++ b/protoc-gen-graphql/template.go
@@ -95,7 +95,8 @@ func Gql__type_{{ .TypeName }}() *graphql.Object {
 			Description: ` + "`" + `{{ .Comment }}` + "`" + `,
 			{{- end }}
 			Fields: graphql.Fields {
-{{- range .Fields }}
+{{- if .Fields }}
+	{{- range .Fields }}
 				{{- if .IsResolve }}
 				{{ $query := .ResolveSubField $.Services }}
 				"{{ .FieldName }}": &graphql.Field{
@@ -158,6 +159,11 @@ func Gql__type_{{ .TypeName }}() *graphql.Object {
 					{{- end }}
 				},
 				{{- end }}
+	{{- end }}
+{{- else }}
+	"_": &graphql.Field{
+		Type: graphql.Boolean,
+	},			
 {{- end }}
 			},
 			{{- if .Interfaces }}
@@ -180,13 +186,19 @@ func Gql__input_{{ .TypeName }}() *graphql.InputObject {
 		gql__input_{{ .TypeName }} =  graphql.NewInputObject(graphql.InputObjectConfig{
 			Name: "{{ $.RootPackage.CamelName }}_Input_{{ .TypeName }}",
 			Fields: graphql.InputObjectConfigFieldMap{
-{{- range .Fields }}
+{{- if .Fields}}
+	{{- range .Fields }}
 				"{{ .FieldName }}": &graphql.InputObjectFieldConfig{
 					{{- if .Comment }}
 					Description: ` + "`" + `{{ .Comment }}` + "`" + `,
 					{{- end }}
 					Type: {{ .FieldTypeInput $.RootPackage.Name }},
 				},
+	{{- end }}
+{{- else }}
+	"_": &graphql.InputObjectFieldConfig{
+		Type: graphql.Boolean,
+	},
 {{- end }}
 			},
 		})


### PR DESCRIPTION
When an empty proto message is defined and used as response for a service, the resulting GraphQL handler for said service tries to respond with a generated gql type that does not exists do to it skipping generation. 

These changes remove the code that skips empty messages for generation and updates the template.go to have a fallback for types and inputs that have no fields in which it uses the graphql pseudo standard of having the only field be a nullable boolean labeled `_`.