### PR TITLE
Resolve camelCase enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## UNRELEASED
+
+- Resolve camelCase enum values ([#13](https://github.com/alehechka/grpc-graphql-gateway/pull/13))
+
 ## [v0.2.4](https://github.com/alehechka/grpc-graphql-gateway/releases/tag/v0.2.4)
 
 - Add compiler and plugin version info to header comment ([#12](https://github.com/alehechka/grpc-graphql-gateway/pull/12))

--- a/example/starwars/Makefile
+++ b/example/starwars/Makefile
@@ -14,6 +14,7 @@ build: init
 			--plugin=../../dist/protoc-gen-graphql \
 			--graphql_out=${SPECDIR} \
 			--graphql_opt=paths=source_relative \
+			--graphql_opt=field_camel \
 			--go_out=:${SPECDIR} \
 			--go_opt=paths=source_relative \
 			--go-grpc_out=:${SPECDIR}  \

--- a/example/starwars/app/graphql/main.go
+++ b/example/starwars/app/graphql/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alehechka/grpc-graphql-gateway/example/starwars/spec/starwars"
 	"github.com/alehechka/grpc-graphql-gateway/runtime"
+	"github.com/friendsofgo/graphiql"
 	"google.golang.org/grpc"
 )
 
@@ -16,6 +17,13 @@ func main() {
 	if err := starwars.RegisterStartwarsServiceGraphqlHandler(mux, nil, "localhost:50051", opts...); err != nil {
 		log.Fatalln(err)
 	}
+
+	graphiqlHandler, err := graphiql.NewGraphiqlHandler("/graphql")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
 	http.Handle("/graphql", mux)
+	http.Handle("/graphiql", graphiqlHandler)
 	log.Fatalln(http.ListenAndServe(":8888", nil))
 }

--- a/example/starwars/spec/starwars/starwars.graphql.go
+++ b/example/starwars/spec/starwars/starwars.graphql.go
@@ -86,13 +86,13 @@ func Gql__interface_Character() *graphql.Interface {
 				"name": &graphql.Field{
 					Type: graphql.String,
 				},
-				"appears_in": &graphql.Field{
+				"appearsIn": &graphql.Field{
 					Type: graphql.NewList(Gql__enum_Episode()),
 				},
-				"home_planet": &graphql.Field{
+				"homePlanet": &graphql.Field{
 					Type: graphql.String,
 				},
-				"primary_function": &graphql.Field{
+				"primaryFunction": &graphql.Field{
 					Type: graphql.String,
 				},
 				"type": &graphql.Field{
@@ -208,13 +208,13 @@ func Gql__type_Character() *graphql.Object {
 				"friends": &graphql.Field{
 					Type: graphql.NewList(Gql__interface_Character()),
 				},
-				"appears_in": &graphql.Field{
+				"appearsIn": &graphql.Field{
 					Type: graphql.NewList(Gql__enum_Episode()),
 				},
-				"home_planet": &graphql.Field{
+				"homePlanet": &graphql.Field{
 					Type: graphql.String,
 				},
-				"primary_function": &graphql.Field{
+				"primaryFunction": &graphql.Field{
 					Type: graphql.String,
 				},
 				"type": &graphql.Field{
@@ -330,13 +330,13 @@ func Gql__input_Character() *graphql.InputObject {
 				"friends": &graphql.InputObjectFieldConfig{
 					Type: graphql.NewList(Gql__interface_Character()),
 				},
-				"appears_in": &graphql.InputObjectFieldConfig{
+				"appearsIn": &graphql.InputObjectFieldConfig{
 					Type: graphql.NewList(Gql__enum_Episode()),
 				},
-				"home_planet": &graphql.InputObjectFieldConfig{
+				"homePlanet": &graphql.InputObjectFieldConfig{
 					Type: graphql.String,
 				},
-				"primary_function": &graphql.InputObjectFieldConfig{
+				"primaryFunction": &graphql.InputObjectFieldConfig{
 					Type: graphql.String,
 				},
 				"type": &graphql.InputObjectFieldConfig{
@@ -400,7 +400,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 			},
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				var req GetHeroRequest
-				if err := runtime.MarshalRequest(p.Args, &req, false); err != nil {
+				if err := runtime.MarshalRequest(p.Args, &req, true); err != nil {
 					return nil, errors.Wrap(err, "Failed to marshal request for hero")
 				}
 				client := NewStartwarsServiceClient(conn)
@@ -408,7 +408,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 				if err != nil {
 					return nil, errors.Wrap(err, "Failed to call RPC GetHero")
 				}
-				return resp, nil
+				return runtime.MarshalResponse(resp), nil
 			},
 		},
 		"human": &graphql.Field{
@@ -421,7 +421,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 			},
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				var req GetHumanRequest
-				if err := runtime.MarshalRequest(p.Args, &req, false); err != nil {
+				if err := runtime.MarshalRequest(p.Args, &req, true); err != nil {
 					return nil, errors.Wrap(err, "Failed to marshal request for human")
 				}
 				client := NewStartwarsServiceClient(conn)
@@ -429,7 +429,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 				if err != nil {
 					return nil, errors.Wrap(err, "Failed to call RPC GetHuman")
 				}
-				return resp, nil
+				return runtime.MarshalResponse(resp), nil
 			},
 		},
 		"droid": &graphql.Field{
@@ -442,7 +442,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 			},
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				var req GetDroidRequest
-				if err := runtime.MarshalRequest(p.Args, &req, false); err != nil {
+				if err := runtime.MarshalRequest(p.Args, &req, true); err != nil {
 					return nil, errors.Wrap(err, "Failed to marshal request for droid")
 				}
 				client := NewStartwarsServiceClient(conn)
@@ -450,7 +450,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 				if err != nil {
 					return nil, errors.Wrap(err, "Failed to call RPC GetDroid")
 				}
-				return resp, nil
+				return runtime.MarshalResponse(resp), nil
 			},
 		},
 		"humans": &graphql.Field{
@@ -458,7 +458,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 			Args: graphql.FieldConfigArgument{},
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				var req ListEmptyRequest
-				if err := runtime.MarshalRequest(p.Args, &req, false); err != nil {
+				if err := runtime.MarshalRequest(p.Args, &req, true); err != nil {
 					return nil, errors.Wrap(err, "Failed to marshal request for humans")
 				}
 				client := NewStartwarsServiceClient(conn)
@@ -466,7 +466,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 				if err != nil {
 					return nil, errors.Wrap(err, "Failed to call RPC ListHumans")
 				}
-				return resp.GetHumans(), nil
+				return runtime.MarshalResponse(resp.GetHumans()), nil
 			},
 		},
 		"droids": &graphql.Field{
@@ -474,7 +474,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 			Args: graphql.FieldConfigArgument{},
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				var req ListEmptyRequest
-				if err := runtime.MarshalRequest(p.Args, &req, false); err != nil {
+				if err := runtime.MarshalRequest(p.Args, &req, true); err != nil {
 					return nil, errors.Wrap(err, "Failed to marshal request for droids")
 				}
 				client := NewStartwarsServiceClient(conn)
@@ -482,7 +482,7 @@ func (x *graphql__resolver_StartwarsService) GetQueries(conn *grpc.ClientConn) g
 				if err != nil {
 					return nil, errors.Wrap(err, "Failed to call RPC ListDroids")
 				}
-				return resp.GetDroids(), nil
+				return runtime.MarshalResponse(resp.GetDroids()), nil
 			},
 		},
 	}

--- a/example/starwars/spec/starwars/starwars.graphql.go
+++ b/example/starwars/spec/starwars/starwars.graphql.go
@@ -41,10 +41,10 @@ func Gql__enum_Type() *graphql.Enum {
 			Name: "Starwars_Enum_Type",
 			Values: graphql.EnumValueConfigMap{
 				"HUMAN": &graphql.EnumValueConfig{
-					Value: Type(0),
+					Value: int32(0),
 				},
 				"DROID": &graphql.EnumValueConfig{
-					Value: Type(1),
+					Value: int32(1),
 				},
 			},
 		})
@@ -58,16 +58,16 @@ func Gql__enum_Episode() *graphql.Enum {
 			Name: "Starwars_Enum_Episode",
 			Values: graphql.EnumValueConfigMap{
 				"_": &graphql.EnumValueConfig{
-					Value: Episode(0),
+					Value: int32(0),
 				},
 				"NEWHOPE": &graphql.EnumValueConfig{
-					Value: Episode(1),
+					Value: int32(1),
 				},
 				"EMPIRE": &graphql.EnumValueConfig{
-					Value: Episode(2),
+					Value: int32(2),
 				},
 				"JEDI": &graphql.EnumValueConfig{
-					Value: Episode(3),
+					Value: int32(3),
 				},
 			},
 		})

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/alehechka/grpc-graphql-gateway
 go 1.18
 
 require (
+	github.com/friendsofgo/graphiql v0.2.2
 	github.com/golang/protobuf v1.5.2
 	github.com/graphql-go/graphql v0.8.0
 	github.com/iancoleman/strcase v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/friendsofgo/graphiql v0.2.2 h1:ccnuxpjgIkB+Lr9YB2ZouiZm7wvciSfqwpa9ugWzmn0=
+github.com/friendsofgo/graphiql v0.2.2/go.mod h1:8Y2kZ36AoTGWs78+VRpvATyt3LJBx0SZXmay80ZTRWo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/protoc-gen-graphql/spec/enum.go
+++ b/protoc-gen-graphql/spec/enum.go
@@ -22,6 +22,7 @@ func NewEnum(
 	d *descriptor.EnumDescriptorProto,
 	f *File,
 	prefix []string,
+	isCamel bool,
 	paths ...int,
 ) *Enum {
 
@@ -37,7 +38,7 @@ func NewEnum(
 	for i, v := range d.GetValue() {
 		ps := make([]int, len(paths))
 		copy(ps, paths)
-		e.values = append(e.values, NewEnumValue(v, f, append(ps, 2, i)...))
+		e.values = append(e.values, NewEnumValue(v, f, isCamel, append(ps, 2, i)...))
 	}
 	return e
 }

--- a/protoc-gen-graphql/spec/enum_value.go
+++ b/protoc-gen-graphql/spec/enum_value.go
@@ -9,18 +9,21 @@ type EnumValue struct {
 	descriptor *descriptor.EnumValueDescriptorProto
 	*File
 
-	paths []int
+	paths   []int
+	isCamel bool
 }
 
 func NewEnumValue(
 	d *descriptor.EnumValueDescriptorProto,
 	f *File,
+	isCamel bool,
 	paths ...int,
 ) *EnumValue {
 
 	return &EnumValue{
 		descriptor: d,
 		File:       f,
+		isCamel:    isCamel,
 		paths:      paths,
 	}
 }
@@ -35,4 +38,11 @@ func (e *EnumValue) Number() int32 {
 
 func (e *EnumValue) Name() string {
 	return e.descriptor.GetName()
+}
+
+func (e *EnumValue) IsCamel() bool {
+	if e != nil {
+		return e.isCamel
+	}
+	return false
 }

--- a/protoc-gen-graphql/spec/file.go
+++ b/protoc-gen-graphql/spec/file.go
@@ -76,7 +76,7 @@ func NewFile(
 		f.messages = append(f.messages, f.messagesRecursive(m, []string{}, 4, i)...)
 	}
 	for i, e := range d.GetEnumType() {
-		f.enums = append(f.enums, NewEnum(e, f, []string{}, 5, i))
+		f.enums = append(f.enums, NewEnum(e, f, []string{}, f.isCamel, 5, i))
 	}
 	return f
 }
@@ -108,7 +108,7 @@ func (f *File) messagesRecursive(d *descriptor.DescriptorProto, prefix []string,
 	for i, e := range d.GetEnumType() {
 		p := make([]int, len(paths))
 		copy(p, paths)
-		f.enums = append(f.enums, NewEnum(e, f, prefix, append(p, 5, i)...))
+		f.enums = append(f.enums, NewEnum(e, f, prefix, f.isCamel, append(p, 5, i)...))
 	}
 
 	for i, m := range d.GetNestedType() {

--- a/protoc-gen-graphql/template/template.go
+++ b/protoc-gen-graphql/template/template.go
@@ -50,7 +50,7 @@ func Gql__enum_{{ .Name }}() *graphql.Enum {
 					{{- if .Comment }}
 					Description: ` + "`" + `{{ .Comment }}` + "`" + `,
 					{{- end }}
-					Value: {{ $enum.Name }}({{ .Number }}),
+					Value: {{ if .IsCamel }}int32{{ else }}{{ $enum.Name }}{{ end }}({{ .Number }}),
 				},
 {{- end }}
 			},

--- a/runtime/response.go
+++ b/runtime/response.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -136,7 +135,6 @@ func marshalMap(v reflect.Value) []mapValue {
 func primitive(v reflect.Value) interface{} {
 	// Guard by cheking IsValid due to prevent panic in runtime
 	if !v.IsValid() {
-		fmt.Println("not valid: ")
 		return nil
 	}
 
@@ -162,7 +160,6 @@ func primitive(v reflect.Value) interface{} {
 	case reflect.Float64:
 		return float64(v.Float())
 	default:
-		fmt.Println("default:", v.Type().Kind())
 		return nil
 	}
 }

--- a/runtime/response.go
+++ b/runtime/response.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -135,6 +136,7 @@ func marshalMap(v reflect.Value) []mapValue {
 func primitive(v reflect.Value) interface{} {
 	// Guard by cheking IsValid due to prevent panic in runtime
 	if !v.IsValid() {
+		fmt.Println("not valid: ")
 		return nil
 	}
 
@@ -160,6 +162,7 @@ func primitive(v reflect.Value) interface{} {
 	case reflect.Float64:
 		return float64(v.Float())
 	default:
+		fmt.Println("default:", v.Type().Kind())
 		return nil
 	}
 }


### PR DESCRIPTION
Prior to this PR, it was found that when using the `field_camel` flag, all gql values were named correctly, however any enum values would be returned from graphql as `null` values. The reason for this is due to the custom marshaling that ends up outputting the enum values as raw `int32` values and thus the graphql resolves doesn't recognize them as the same as `Type(#)` casted valued. 

To resolve this, I updated the `template.go` to include an if/else around the enum value that will conditional generate it as the actual Go type as previous, or as `int32`. 

This makes it so when not using the `field_camel` flag it continues to work as expected, but now when using it the enum values will be returned correctly instead of all nulls.